### PR TITLE
Fix link to ligature GH issue in faq

### DIFF
--- a/website/__site/faq/index.html
+++ b/website/__site/faq/index.html
@@ -113,7 +113,7 @@ code &#123;
 <h3 id="a_tale_of_two_ttys"><a href="#a_tale_of_two_ttys" class="header-anchor">A tale of two TTYs</a></h3>
 <p>In VSCode there are two levels of OpenType font support, <em>editor</em> and <em>terminal</em>.</p>
 <p>Editor windows support most OpenType features; you can ask for contextual alternates &#40;ligatures&#41;, stylistic sets, alternate characters, and so on, using the feature codes listed above.</p>
-<p>Terminal windows use the xterm.js terminal emulator. This doesn&#39;t &#40;yet&#41; support OpenType features such as ligatures, stylistic sets, etc. To keep up with any improvement here, keep an eye on <a href="https://github.com/xtermjs/xterm.js/issues/9580">this Github issue</a>.</p>
+<p>Terminal windows use the xterm.js terminal emulator. This doesn&#39;t &#40;yet&#41; support OpenType features such as ligatures, stylistic sets, etc. To keep up with any improvement here, keep an eye on <a href="https://github.com/xtermjs/xterm.js/issues/958">this Github issue</a>.</p>
 <h2 id="how_do_i_configure_the_css"><a href="#how_do_i_configure_the_css" class="header-anchor">‘How do I configure the CSS?’</a></h2>
 <p>In a CSS stylesheet, you can specify the appearance of the font. First, define the location of the online fonts:</p>
 <pre><code class="language-css">@font-face &#123;

--- a/website/faq.md
+++ b/website/faq.md
@@ -117,7 +117,7 @@ In VSCode there are two levels of OpenType font support, _editor_ and _terminal_
 
 Editor windows support most OpenType features; you can ask for contextual alternates (ligatures), stylistic sets, alternate characters, and so on, using the feature codes listed above.
 
-Terminal windows use the xterm.js terminal emulator. This doesn't (yet) support OpenType features such as ligatures, stylistic sets, etc. To keep up with any improvement here, keep an eye on [this Github issue](https://github.com/xtermjs/xterm.js/issues/9580).
+Terminal windows use the xterm.js terminal emulator. This doesn't (yet) support OpenType features such as ligatures, stylistic sets, etc. To keep up with any improvement here, keep an eye on [this Github issue](https://github.com/xtermjs/xterm.js/issues/958).
 
 ## ‘How do I configure the CSS?’
 


### PR DESCRIPTION
The FAQ had a typo in the link to the GitHub issue https://github.com/xtermjs/xterm.js/issues/958 (issue 958**0** does not exist)