### PR TITLE
updated brew installation instructions

### DIFF
--- a/website/__site/download/index.html
+++ b/website/__site/download/index.html
@@ -67,8 +67,7 @@
 <p>To install and activate a font, launch Font Book from your Applications folder, and drag the font files into the middle pane labelled Font. If you&#39;re using a different font manager, you already know what to do. :&#41;</p>
 <h4 id="macos_homebrew"><a href="#macos_homebrew" class="header-anchor">MacOS Homebrew</a></h4>
 <p>On the latest version of Homebrew, you can install the fonts with:</p>
-<pre><code class="language-julia">brew tap homebrew/cask-fonts
-brew install --cask font-juliamono</code></pre>
+<pre><code class="language-julia">brew install font-juliamono</code></pre>
 <h3 id="windows"><a href="#windows" class="header-anchor">Windows</a></h3>
 <p>You can install a font for a single user or for all users. &#40;Some applications &#40;such as Java&#41; don&#39;t see fonts unless they have been installed for all users.&#41;</p>
 <p>To install and activate a font on Windows, go to Computer |&gt; Local Disk &#40;C:&#41; |&gt; Windows |&gt; Fonts. Locate the expanded .zip file folder, and drag the font files from there into the Fonts folder.</p>
@@ -90,7 +89,7 @@ brew install --cask font-juliamono</code></pre>
 <pre><code class="language-julia">&#36; fc-list | grep &quot;JuliaMono&quot;</code></pre>
 <div class="page-foot">
   <div class="copyright">
-    &copy; Cormullion. Last modified: October 20, 2024. Font version . Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the Julia Programming Language, based on the "basic" template.
+    &copy; Cormullion. Last modified: April 30, 2025. Font version . Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the Julia Programming Language, based on the "basic" template.
   </div>
 </div>
 </div><!-- CONTENT ENDS HERE -->

--- a/website/__site/faq/index.html
+++ b/website/__site/faq/index.html
@@ -391,7 +391,7 @@ display&#40;p&#41;</code></pre>
 <p></p>
 <div class="page-foot">
   <div class="copyright">
-    &copy; Cormullion. Last modified: October 20, 2024. Font version . Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the Julia Programming Language, based on the "basic" template.
+    &copy; Cormullion. Last modified: April 30, 2025. Font version . Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the Julia Programming Language, based on the "basic" template.
   </div>
 </div>
 </div><!-- CONTENT ENDS HERE -->

--- a/website/__site/index.html
+++ b/website/__site/index.html
@@ -923,7 +923,7 @@ Welcome to </code></pre>
 </p>
 <div class="page-foot">
   <div class="copyright">
-    &copy; Cormullion. Last modified: October 20, 2024. Font version . Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the Julia Programming Language, based on the "basic" template.
+    &copy; Cormullion. Last modified: April 30, 2025. Font version . Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the Julia Programming Language, based on the "basic" template.
   </div>
 </div>
 </div><!-- CONTENT ENDS HERE -->

--- a/website/__site/sitemap.xml
+++ b/website/__site/sitemap.xml
@@ -2,26 +2,26 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
 <url>
-    <loc>index.html</loc>
-    <lastmod>2024-10-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-</url>
-<url>
     <loc>faq/index.html</loc>
-    <lastmod>2024-10-20</lastmod>
+    <lastmod>2025-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
 </url>
 <url>
     <loc>download/index.html</loc>
-    <lastmod>2024-10-20</lastmod>
+    <lastmod>2025-04-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+</url>
+<url>
+    <loc>index.html</loc>
+    <lastmod>2025-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
 </url>
 <url>
     <loc>glyphs/</loc>
-    <lastmod>2024-10-20</lastmod>
+    <lastmod>2025-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
 </url>

--- a/website/download.md
+++ b/website/download.md
@@ -29,8 +29,7 @@ To install and activate a font, launch Font Book from your Applications folder, 
 On the latest version of Homebrew, you can install the fonts with:
 
 ```
-brew tap homebrew/cask-fonts
-brew install --cask font-juliamono
+brew install font-juliamono
 ```
 
 ### Windows


### PR DESCRIPTION
the `homebrew/cask-fonts` has been deprecated. see error: 
```shell
$ brew tap homebrew/cask-fonts
Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```

Fonts can now be installed directly using 
```shell
brew install font-juliamono
```