### PR TITLE
fix brew instructions again, needs --cask flag (with no args)

### DIFF
--- a/website/download.md
+++ b/website/download.md
@@ -29,7 +29,7 @@ To install and activate a font, launch Font Book from your Applications folder, 
 On the latest version of Homebrew, you can install the fonts with:
 
 ```
-brew install font-juliamono
+brew install --cask font-juliamono
 ```
 
 ### Windows


### PR DESCRIPTION
I tried installing juliamono on a new machine, and realized that you need --cask (with no specific cask added)